### PR TITLE
Added pause for allowing ADB permissions in device

### DIFF
--- a/Tweaks.bat
+++ b/Tweaks.bat
@@ -2,6 +2,9 @@ echo Tweaks Script by invinciblevenom
 echo =============================================
 echo Checking connected devices
 adb devices
+
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
 echo Boost Battery
 adb shell settings put global adaptive_battery_management_enabled 0
 adb shell settings put global cached_apps_freezer enabled

--- a/debloat/Basic_debloat.bat
+++ b/debloat/Basic_debloat.bat
@@ -1,5 +1,10 @@
 echo Basic Debloat Script by invinciblevenom@github
 adb devices
+
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
+echo Starting debloat...
+
 adb shell pm uninstall --user 0 android.autoinstalls.config.samsung
 adb shell pm uninstall --user 0 com.android.bips
 adb shell pm uninstall --user 0 com.android.bookmarkprovider
@@ -103,4 +108,5 @@ adb shell pm uninstall --user 0 com.sec.spp.push
 adb shell pm uninstall --user 0 com.snap.camerakit.plugin.v1                         
 echo Killing adb server
 adb kill-server
+echo Debloat process finished.
 pause 

--- a/debloat/Heavy_debloat.bat
+++ b/debloat/Heavy_debloat.bat
@@ -1,5 +1,10 @@
 echo Heavy Debloat Script by invinciblevenom
 adb devices
+
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
+echo Starting debloat...
+
 #adb shell pm uninstall --user 0 com.samsung.android.mdx
 #adb shell pm uninstall --user 0 com.samsung.android.mdx.kit
 #adb shell pm uninstall --user 0 com.samsung.android.smartmirroring                     #Smart View
@@ -326,4 +331,6 @@ adb shell cmd package install-existing com.sec.android.soagent
 adb shell cmd package install-existing com.sec.android.systemupdate 
 echo Killing adb server
 adb kill-server
+
+echo Debloat process finished.
 pause 

--- a/debloat/Light_debloat.bat
+++ b/debloat/Light_debloat.bat
@@ -1,5 +1,10 @@
 echo Light Debloat Script by invinciblevenom@github
 adb devices
+
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
+echo Starting debloat...
+
 #adb shell pm uninstall --user 0 com.android.emergency
 #adb shell pm uninstall --user 0 com.google.android.gms.location.history
 #adb shell pm uninstall --user 0 com.samsung.android.mdx.kit
@@ -163,4 +168,5 @@ adb shell pm uninstall --user 0 com.sec.spp.push
 adb shell pm uninstall --user 0 com.snap.camerakit.plugin.v1                           
 echo Killing adb server
 adb kill-server
+echo Debloat process finished.
 pause 

--- a/revert/Revert_Basic_debloat.bat
+++ b/revert/Revert_Basic_debloat.bat
@@ -2,6 +2,11 @@ echo Revert for Basic Debloat Script by invinciblevenom
 echo =============================================
 echo Checking connected devices
 adb devices
+
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
+echo Starting debloat Revert...
+
 adb shell cmd package install-existing android.autoinstalls.config.samsung
 adb shell cmd package install-existing com.android.bips
 adb shell cmd package install-existing com.android.bookmarkprovider

--- a/revert/Revert_Heavy_debloat.bat
+++ b/revert/Revert_Heavy_debloat.bat
@@ -2,6 +2,10 @@ echo Revert for Heavy Debloat Script by invinciblevenom
 echo =============================================
 echo Checking connected devices
 adb devices
+
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
+echo Starting debloat Revert...
 #adb shell cmd package install-existing com.samsung.android.mdx
 #adb shell cmd package install-existing com.samsung.android.mdx.kit
 #adb shell cmd package install-existing com.samsung.android.smartmirroring                     #Smart View

--- a/revert/Revert_Light_debloat.bat
+++ b/revert/Revert_Light_debloat.bat
@@ -2,6 +2,9 @@ echo Revert for Light Debloat Script by invinciblevenom
 echo =============================================
 echo Checking connected devices
 adb devices
+pause ALLOW ADB PERMISSIONS IN DEVICE...
+
+echo Starting debloat Revert...
 #adb shell cmd package install-existing com.android.emergency
 #adb shell cmd package install-existing com.google.android.gms.location.history
 #adb shell cmd package install-existing com.samsung.android.mdx.kit


### PR DESCRIPTION
### Description:
This PR introduces a `pause` in the script that prompts users to "ALLOW ADB PERMISSIONS IN DEVICE..." This ensures that users have the chance to authorize ADB access on their device before the script continues, preventing potential issues where the device is unauthorized.

### Reason for the change:
In the previous version, the script could proceed before the user had a chance to grant ADB permissions, which could cause errors. This update improves the workflow by adding a clear prompt and a pause, ensuring the process continues only after ADB permissions are granted.

Let me know if you need any adjustments or further explanations!
